### PR TITLE
Potential security issue in lib/curl_sasl.c: Unchecked return from initialization function

### DIFF
--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -430,6 +430,7 @@ CURLcode Curl_sasl_continue(struct SASL *sasl, struct connectdata *conn,
                         data->set.str[STRING_SERVICE_NAME] :
                         sasl->params->service;
   char *serverdata;
+  serverdata = (void*)0;
 #endif
   size_t len = 0;
   const char *oauth_bearer = data->set.str[STRING_BEARER];


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> When an initialization function is used to initialize a local variable, but the returned status code is not checked, reading the variable may result in undefined behaviour.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `lib/curl_sasl.c` 
Function: `Curl_sasl_continue` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/curl_sasl.c#L476
Code extract:

```cpp

#ifndef CURL_DISABLE_CRYPTO_AUTH
  case SASL_CRAMMD5:
    sasl->params->getmessage(data->state.buffer, &serverdata); <------ HERE
    result = Curl_auth_decode_cram_md5_message(serverdata, &chlg, &chlglen);
    if(!result)
```

