### PR TITLE
Potential security issue in lib/socks_sspi.c: Unchecked return from initialization function

### DIFF
--- a/lib/socks_sspi.c
+++ b/lib/socks_sspi.c
@@ -78,6 +78,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(int sockindex,
   SecPkgContext_Sizes sspi_sizes;
   CredHandle cred_handle;
   CtxtHandle sspi_context;
+  sspi_context = {};
   PCtxtHandle context_handle = NULL;
   SecPkgCredentials_Names names;
   TimeStamp expiry;


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> When an initialization function is used to initialize a local variable, but the returned status code is not checked, reading the variable may result in undefined behaviour.</span>
---

25 instances of this defect were found in the following locations:
---
**Instance 1**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L194
Code extract:

```cpp
    if(check_sspi_err(conn, status, "InitializeSecurityContext")) {
      free(service_name);
      s_pSecFn->FreeCredentialsHandle(&cred_handle);
      s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
      if(sspi_recv_token.pvBuffer)
        s_pSecFn->FreeContextBuffer(sspi_recv_token.pvBuffer);
```

---
**Instance 2**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L216
Code extract:

```cpp
        if(sspi_recv_token.pvBuffer)
          s_pSecFn->FreeContextBuffer(sspi_recv_token.pvBuffer);
        s_pSecFn->FreeCredentialsHandle(&cred_handle);
        s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
        return CURLE_COULDNT_CONNECT;
      }
```

---
**Instance 3**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L230
Code extract:

```cpp
        if(sspi_recv_token.pvBuffer)
          s_pSecFn->FreeContextBuffer(sspi_recv_token.pvBuffer);
        s_pSecFn->FreeCredentialsHandle(&cred_handle);
        s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
        return CURLE_COULDNT_CONNECT;
      }
```

---
**Instance 4**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L266
Code extract:

```cpp
      failf(data, "Failed to receive SSPI authentication response.");
      free(service_name);
      s_pSecFn->FreeCredentialsHandle(&cred_handle);
      s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
      return CURLE_COULDNT_CONNECT;
    }
```

---
**Instance 5**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L276
Code extract:

```cpp
            (unsigned int)socksreq[0], (unsigned int)socksreq[1]);
      free(service_name);
      s_pSecFn->FreeCredentialsHandle(&cred_handle);
      s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
      return CURLE_COULDNT_CONNECT;
    }
```

---
**Instance 6**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L285
Code extract:

```cpp
            (unsigned int)socksreq[0], (unsigned int)socksreq[1]);
      free(service_name);
      s_pSecFn->FreeCredentialsHandle(&cred_handle);
      s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
      return CURLE_COULDNT_CONNECT;
    }
```

---
**Instance 7**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L298
Code extract:

```cpp
    if(!sspi_recv_token.pvBuffer) {
      free(service_name);
      s_pSecFn->FreeCredentialsHandle(&cred_handle);
      s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
      return CURLE_OUT_OF_MEMORY;
    }
```

---
**Instance 8**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L310
Code extract:

```cpp
      if(sspi_recv_token.pvBuffer)
        s_pSecFn->FreeContextBuffer(sspi_recv_token.pvBuffer);
      s_pSecFn->FreeCredentialsHandle(&cred_handle);
      s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
      return CURLE_COULDNT_CONNECT;
    }
```

---
**Instance 9**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L325
Code extract:

```cpp
                                                &names);
  s_pSecFn->FreeCredentialsHandle(&cred_handle);
  if(check_sspi_err(conn, status, "QueryCredentialAttributes")) {
    s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
    s_pSecFn->FreeContextBuffer(names.sUserName);
    failf(data, "Failed to determine user name.");
```

---
**Instance 10**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L390
Code extract:

```cpp
                                              SECPKG_ATTR_SIZES,
                                              &sspi_sizes);
    if(check_sspi_err(conn, status, "QueryContextAttributes")) {
      s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
      failf(data, "Failed to query security context attributes.");
      return CURLE_COULDNT_CONNECT;
```

---
**Instance 11**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L400
Code extract:

```cpp
    sspi_w_token[0].pvBuffer = malloc(sspi_sizes.cbSecurityTrailer);

    if(!sspi_w_token[0].pvBuffer) {
      s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
      return CURLE_OUT_OF_MEMORY;
    }
```

---
**Instance 12**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L408
Code extract:

```cpp
    sspi_w_token[1].pvBuffer = malloc(1);
    if(!sspi_w_token[1].pvBuffer) {
      s_pSecFn->FreeContextBuffer(sspi_w_token[0].pvBuffer);
      s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
      return CURLE_OUT_OF_MEMORY;
    }
```

---
**Instance 13**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L419
Code extract:

```cpp
    if(!sspi_w_token[2].pvBuffer) {
      s_pSecFn->FreeContextBuffer(sspi_w_token[0].pvBuffer);
      s_pSecFn->FreeContextBuffer(sspi_w_token[1].pvBuffer);
      s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
      return CURLE_OUT_OF_MEMORY;
    }
```

---
**Instance 14**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L430
Code extract:

```cpp
      s_pSecFn->FreeContextBuffer(sspi_w_token[0].pvBuffer);
      s_pSecFn->FreeContextBuffer(sspi_w_token[1].pvBuffer);
      s_pSecFn->FreeContextBuffer(sspi_w_token[2].pvBuffer);
      s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
      failf(data, "Failed to query security context attributes.");
      return CURLE_COULDNT_CONNECT;
```

---
**Instance 15**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L442
Code extract:

```cpp
      s_pSecFn->FreeContextBuffer(sspi_w_token[0].pvBuffer);
      s_pSecFn->FreeContextBuffer(sspi_w_token[1].pvBuffer);
      s_pSecFn->FreeContextBuffer(sspi_w_token[2].pvBuffer);
      s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
      return CURLE_OUT_OF_MEMORY;
    }
```

---
**Instance 16**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L474
Code extract:

```cpp
    failf(data, "Failed to send SSPI encryption request.");
    if(sspi_send_token.pvBuffer)
      s_pSecFn->FreeContextBuffer(sspi_send_token.pvBuffer);
    s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
    return CURLE_COULDNT_CONNECT;
  }
```

---
**Instance 17**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L483
Code extract:

```cpp
    code = Curl_write_plain(conn, sock, (char *)socksreq, 1, &written);
    if(code || (1 != written)) {
      failf(data, "Failed to send SSPI encryption type.");
      s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
      return CURLE_COULDNT_CONNECT;
    }
```

---
**Instance 18**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L494
Code extract:

```cpp
      failf(data, "Failed to send SSPI encryption type.");
      if(sspi_send_token.pvBuffer)
        s_pSecFn->FreeContextBuffer(sspi_send_token.pvBuffer);
      s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
      return CURLE_COULDNT_CONNECT;
    }
```

---
**Instance 19**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L504
Code extract:

```cpp
  result = Curl_blockread_all(conn, sock, (char *)socksreq, 4, &actualread);
  if(result || (actualread != 4)) {
    failf(data, "Failed to receive SSPI encryption response.");
    s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
    return CURLE_COULDNT_CONNECT;
  }
```

---
**Instance 20**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L512
Code extract:

```cpp
  if(socksreq[1] == 255) { /* status / message type */
    failf(data, "User was rejected by the SOCKS5 server (%u %u).",
          (unsigned int)socksreq[0], (unsigned int)socksreq[1]);
    s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
    return CURLE_COULDNT_CONNECT;
  }
```

---
**Instance 21**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L519
Code extract:

```cpp
  if(socksreq[1] != 2) { /* status / message type */
    failf(data, "Invalid SSPI encryption response type (%u %u).",
          (unsigned int)socksreq[0], (unsigned int)socksreq[1]);
    s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
    return CURLE_COULDNT_CONNECT;
  }
```

---
**Instance 22**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L529
Code extract:

```cpp
  sspi_w_token[0].cbBuffer = us_length;
  sspi_w_token[0].pvBuffer = malloc(us_length);
  if(!sspi_w_token[0].pvBuffer) {
    s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
    return CURLE_OUT_OF_MEMORY;
  }
```

---
**Instance 23**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L539
Code extract:

```cpp
  if(result || (actualread != us_length)) {
    failf(data, "Failed to receive SSPI encryption type.");
    s_pSecFn->FreeContextBuffer(sspi_w_token[0].pvBuffer);
    s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
    return CURLE_COULDNT_CONNECT;
  }
```

---
**Instance 24**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L561
Code extract:

```cpp
        s_pSecFn->FreeContextBuffer(sspi_w_token[0].pvBuffer);
      if(sspi_w_token[1].pvBuffer)
        s_pSecFn->FreeContextBuffer(sspi_w_token[1].pvBuffer);
      s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
      failf(data, "Failed to query security context attributes.");
      return CURLE_COULDNT_CONNECT;
```

---
**Instance 25**
File : `lib/socks_sspi.c` 
Function: `Curl_SOCKS5_gssapi_negotiate` 
https://github.com/siva-msft/curl/blob/a051c0f0a9057a792ce7dfa22bf761d36fc56a72/lib/socks_sspi.c#L573
Code extract:

```cpp
        s_pSecFn->FreeContextBuffer(sspi_w_token[0].pvBuffer);
      if(sspi_w_token[1].pvBuffer)
        s_pSecFn->FreeContextBuffer(sspi_w_token[1].pvBuffer);
      s_pSecFn->DeleteSecurityContext(&sspi_context); <------ HERE
      return CURLE_COULDNT_CONNECT;
    }
```

