### PR TITLE
Potential security issue in lib/sha256.c: Unchecked return from initialization function

### DIFF
--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -223,6 +223,7 @@ static void SHA256_Update(SHA256_CTX *ctx,
 static void SHA256_Final(unsigned char *digest, SHA256_CTX *ctx)
 {
   unsigned long length;
+  length = 0;
 
   CryptGetHashParam(ctx->hHash, HP_HASHVAL, NULL, &length, 0);
   if(length == SHA256_DIGEST_LENGTH)


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `lib/sha256.c` 
Function: `CryptGetHashParam` 
https://github.com/siva-msft/curl/blob/6374c826c173e84ef964c4316686bef5481516a7/lib/sha256.c#L227
Code extract:

```cpp
{
  unsigned long length;

  CryptGetHashParam(ctx->hHash, HP_HASHVAL, NULL, &length, 0); <------ HERE
  if(length == SHA256_DIGEST_LENGTH)
    CryptGetHashParam(ctx->hHash, HP_HASHVAL, digest, &length, 0);
```

