### PR TITLE
Potential security issue in src/tool_urlglob.c: Unchecked return from initialization function

### DIFF
--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -200,6 +200,7 @@ static CURLcode glob_range(URLGlob *glob, char **patternp,
     if(rc == 3) {
       if(end_c == ':') {
         char *endp;
+        endp = (void*)0;
         errno = 0;
         step = strtoul(&pattern[4], &endp, 10);
         if(errno || &pattern[4] == endp || *endp != ']')


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src/tool_urlglob.c` 
Function: `strtoul` 
https://github.com/siva-msft/curl/blob/6374c826c173e84ef964c4316686bef5481516a7/src/tool_urlglob.c#L204
Code extract:

```cpp
      if(end_c == ':') {
        char *endp;
        errno = 0;
        step = strtoul(&pattern[4], &endp, 10); <------ HERE
        if(errno || &pattern[4] == endp || *endp != ']')
          step = 0;
```

