### PR TITLE
Potential security issue in src/tool_operate.c: Unchecked return from initialization function

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -453,6 +453,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
     else if(config->retry_connrefused &&
             (CURLE_COULDNT_CONNECT == result)) {
       long oserrno;
+      oserrno = 0;
       curl_easy_getinfo(curl, CURLINFO_OS_ERRNO, &oserrno);
       if(ECONNREFUSED == oserrno)
         retry = RETRY_CONNREFUSED;


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src/tool_operate.c` 
Function: `curl_easy_getinfo` 
https://github.com/siva-msft/curl/blob/91176082b1cf013b3510b7544b589973e541e8b4/src/tool_operate.c#L456
Code extract:

```cpp
    else if(config->retry_connrefused &&
            (CURLE_COULDNT_CONNECT == result)) {
      long oserrno;
      curl_easy_getinfo(curl, CURLINFO_OS_ERRNO, &oserrno); <------ HERE
      if(ECONNREFUSED == oserrno)
        retry = RETRY_CONNREFUSED;
```

