### PR TITLE
Potential security issue in src/tool_paramhlp.c: Unchecked return from initialization function

### DIFF
--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -181,6 +181,7 @@ ParameterError str2num(long *val, const char *str)
 {
   if(str) {
     char *endptr;
+    endptr = (void*)0;
     long num;
     errno = 0;
     num = strtol(str, &endptr, 10);


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src/tool_paramhlp.c` 
Function: `strtol` 
https://github.com/siva-msft/curl/blob/91176082b1cf013b3510b7544b589973e541e8b4/src/tool_paramhlp.c#L186
Code extract:

```cpp
    char *endptr;
    long num;
    errno = 0;
    num = strtol(str, &endptr, 10); <------ HERE
    if(errno == ERANGE)
      return PARAM_NUMBER_TOO_LARGE;
```

