### PR TITLE
Potential security issue in src/tool_operate.c: Unchecked return from initialization function

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -444,6 +444,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
       RETRY_LAST /* not used */
     } retry = RETRY_NO;
     long response;
+    response = 0;
     if((CURLE_OPERATION_TIMEDOUT == result) ||
        (CURLE_COULDNT_RESOLVE_HOST == result) ||
        (CURLE_COULDNT_RESOLVE_PROXY == result) ||
@@ -453,6 +454,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
     else if(config->retry_connrefused &&
             (CURLE_COULDNT_CONNECT == result)) {
       long oserrno;
+      oserrno = 0;
       curl_easy_getinfo(curl, CURLINFO_OS_ERRNO, &oserrno);
       if(ECONNREFUSED == oserrno)
         retry = RETRY_CONNREFUSED;
@@ -464,6 +466,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
          returned due to such an error, check for HTTP transient
          errors to retry on. */
       long protocol;
+      protocol = 0;
       curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol);
       if((protocol == CURLPROTO_HTTP) || (protocol == CURLPROTO_HTTPS)) {
         /* This was HTTP(S) */
@@ -492,6 +495,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
     } /* if CURLE_OK */
     else if(result) {
       long protocol;
+      protocol = 0;
 
       curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response);
       curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol);
@@ -585,6 +589,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
     /* Metalink: Decide to try the next resource or not. Try the next resource
        if download was not successful. */
     long response;
+    response = 0;
     if(CURLE_OK == result) {
       /* TODO We want to try next resource when download was
          not successful. How to know that? */


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

6 instances of this defect were found in the following locations:
---
**Instance 1**
File : `src/tool_operate.c` 
Function: `curl_easy_getinfo` 
https://github.com/siva-msft/curl/blob/58049f7b4e455b4fc6c4bfa96420852627b4cae8/src/tool_operate.c#L456
Code extract:

```cpp
    else if(config->retry_connrefused &&
            (CURLE_COULDNT_CONNECT == result)) {
      long oserrno;
      curl_easy_getinfo(curl, CURLINFO_OS_ERRNO, &oserrno); <------ HERE
      if(ECONNREFUSED == oserrno)
        retry = RETRY_CONNREFUSED;
```

---
**Instance 2**
File : `src/tool_operate.c` 
Function: `curl_easy_getinfo` 
https://github.com/siva-msft/curl/blob/58049f7b4e455b4fc6c4bfa96420852627b4cae8/src/tool_operate.c#L467
Code extract:

```cpp
         returned due to such an error, check for HTTP transient
         errors to retry on. */
      long protocol;
      curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol); <------ HERE
      if((protocol == CURLPROTO_HTTP) || (protocol == CURLPROTO_HTTPS)) {
        /* This was HTTP(S) */
```

---
**Instance 3**
File : `src/tool_operate.c` 
Function: `curl_easy_getinfo` 
https://github.com/siva-msft/curl/blob/58049f7b4e455b4fc6c4bfa96420852627b4cae8/src/tool_operate.c#L470
Code extract:

```cpp
      curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol);
      if((protocol == CURLPROTO_HTTP) || (protocol == CURLPROTO_HTTPS)) {
        /* This was HTTP(S) */
        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response); <------ HERE

        switch(response) {
```

---
**Instance 4**
File : `src/tool_operate.c` 
Function: `curl_easy_getinfo` 
https://github.com/siva-msft/curl/blob/58049f7b4e455b4fc6c4bfa96420852627b4cae8/src/tool_operate.c#L496
Code extract:

```cpp
    else if(result) {
      long protocol;

      curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response); <------ HERE
      curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol);

```

---
**Instance 5**
File : `src/tool_operate.c` 
Function: `curl_easy_getinfo` 
https://github.com/siva-msft/curl/blob/58049f7b4e455b4fc6c4bfa96420852627b4cae8/src/tool_operate.c#L497
Code extract:

```cpp
      long protocol;

      curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response);
      curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol); <------ HERE

      if((protocol == CURLPROTO_FTP || protocol == CURLPROTO_FTPS) &&
```

---
**Instance 6**
File : `src/tool_operate.c` 
Function: `curl_easy_getinfo` 
https://github.com/siva-msft/curl/blob/58049f7b4e455b4fc6c4bfa96420852627b4cae8/src/tool_operate.c#L596
Code extract:

```cpp
      if(effective_url &&
         curl_strnequal(effective_url, "http", 4)) {
        /* This was HTTP(S) */
        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response); <------ HERE
        if(response != 200 && response != 206) {
          per->metalink_next_res = 1;
```

